### PR TITLE
questions

### DIFF
--- a/clientDB/src/main/java/com/myhomeDB/AppDB.java
+++ b/clientDB/src/main/java/com/myhomeDB/AppDB.java
@@ -5,8 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
-@SpringBootApplication(scanBasePackages = {"test"} , exclude = JpaRepositoriesAutoConfiguration.class)
-//@SpringBootApplication
+//@SpringBootApplication(scanBasePackages = {"test"} , exclude = JpaRepositoriesAutoConfiguration.class)
+@SpringBootApplication
 @EnableEurekaClient
 public class AppDB {
     public static void main(String[] args) {


### PR DESCRIPTION
1) модуль clientDB получилось запустить только с 
@SpringBootApplication(scanBasePackages = {"test"} , exclude = JpaRepositoriesAutoConfiguration.class)
почему в стандарте не получается? И что это значит?
Позже почему-то перестал запускаться с ошибкой из п.3 (см. ниже)


2) при запуске eureka-server выдает такую ошибку:
Description:
An attempt was made to call a method that does not exist. The attempt was made from the following location:
    org.apache.catalina.authenticator.AuthenticatorBase.startInternal(AuthenticatorBase.java:1355)
The following method did not exist:
    'java.lang.String javax.servlet.ServletContext.getVirtualServerName()'
The method's class, javax.servlet.ServletContext, is available from the following locations:
    jar:file:/C:/Users/%d0%bd%d0%be%d0%b2%d1%8b%d0%b9%20%d0%bf%d0%be%d0%bb%d1%8c%d0%b7%d0%be%d0%b2%d0%b0%d1%82%d0%b5%d0%bb%d1%8c/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar!/javax/servlet/ServletContext.class
    jar:file:/C:/Users/%d0%bd%d0%be%d0%b2%d1%8b%d0%b9%20%d0%bf%d0%be%d0%bb%d1%8c%d0%b7%d0%be%d0%b2%d0%b0%d1%82%d0%b5%d0%bb%d1%8c/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/9.0.52/tomcat-embed-core-9.0.52.jar!/javax/servlet/ServletContext.class

The class hierarchy was loaded from the following locations:
    javax.servlet.ServletContext: file:/C:/Users/%d0%bd%d0%be%d0%b2%d1%8b%d0%b9%20%d0%bf%d0%be%d0%bb%d1%8c%d0%b7%d0%be%d0%b2%d0%b0%d1%82%d0%b5%d0%bb%d1%8c/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar

Action:
Correct the classpath of your application so that it contains a single, compatible version of javax.servlet.ServletContext

После удаления этой папки eureka-server запускается:
C:/Users/%d0%bd%d0%be%d0%b2%d1%8b%d0%b9%20%d0%bf%d0%be%d0%bb%d1%8c%d0%b7%d0%be%d0%b2%d0%b0%d1%82%d0%b5%d0%bb%d1%8c/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar

Просит исправить путь к классу. Как его исправить или обойти это?


3) при запуске clientDB и clientFront такая ошибка:
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'configurationPropertiesBeans' defined in class path resource [org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.class]: Post-processing of merged bean definition failed; nested exception is java.lang.IllegalStateException: Failed to introspect Class [org.springframework.cloud.context.properties.ConfigurationPropertiesBeans] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@5a07e868]
Что надо делать ?
